### PR TITLE
Add Tick as a separator for the thousands separator

### DIFF
--- a/Model/System/Config/Source/GroupSeparator.php
+++ b/Model/System/Config/Source/GroupSeparator.php
@@ -36,6 +36,7 @@ class GroupSeparator extends OptionArray
             self::COMMA => __('Comma (,)'),
             self::DOT   => __('Dot (.)'),
             self::SPACE => __('Space ( )'),
+            self::TICK => __("Tick (')"),
             self::NONE  => __('None'),
         ];
     }

--- a/Model/System/Config/Source/OptionArray.php
+++ b/Model/System/Config/Source/OptionArray.php
@@ -29,6 +29,7 @@ use Magento\Framework\Option\ArrayInterface;
  */
 abstract class OptionArray implements ArrayInterface
 {
+    const TICK = "'";
     const COMMA = ',';
     const DOT   = '.';
     const SPACE = ' ';

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "mageplaza/module-core": "^1.4.5"
   },
   "type": "magento2-module",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "license": "proprietary",
   "authors": [
     {


### PR DESCRIPTION
In Switserland it is normal to have the single tick as separator for the thousands. Therefor to be able to support swiss websites, its important to have the tick added.

### Description
Tick was added, i have used double quotes to add the tick, because its easier to read aswell as nothing can go wrong with double escaping

### Fixed Issues (if relevant)

### Manual testing scenarios
Tested if i was able to set the tick in the backend

### Contribution checklist
 - [V] Pull request has a meaningful description of its purpose
 - [V] All commits are accompanied by meaningful commit messages
 - [NA] All new or changed code is covered with unit/integration tests (if applicable)