### PR TITLE
Fix broken decimal separator replacement when it is more than one byte length (don't assume it's length always 1). Eg: ar_SA locale.

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -363,12 +363,13 @@ class Data extends AbstractData
             return str_replace($original['groupSymbol'], $config['group_separator'], $processedCurrency);
         }
 
-        $decimalPart = substr($result, -($decimal + 1), $decimal + 1);
-        $currencyPart = substr($result, 0, strlen($result) - ($decimal + 1));
+        $decimalSeparatorLength = strlen($original['decimalSymbol']);
+        $decimalPart = substr($result, -($decimal + $decimalSeparatorLength), $decimal + $decimalSeparatorLength);
+        $currencyPart = substr($result, 0, strlen($result) - ($decimal + $decimalSeparatorLength));
         $currencyPartResult = str_replace($original['groupSymbol'], $config['group_separator'], $currencyPart);
         $decimalPartResult = str_replace($original['decimalSymbol'], $config['decimal_separator'], $decimalPart);
         $result = $currencyPartResult . $decimalPartResult;
-
+        
         return $this->processShowSymbol($config['symbol'], $result, $config['show_symbol'], $negative);
     }
 


### PR DESCRIPTION
This change makes handling unicode decimal separators work.

### Manual testing scenarios
- Set locale to ar_SA and currency to Saudi Riyal and language to Arabic.
- Override the format with this plugin.
- Before this PR, the decimal separator is not properly replaced in all cases (due to unicode truncation).
- After this PR, decimal separator of any number of bytes is handled correctly.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
