### PR TITLE
Fetch base currency code from current store

### DIFF
--- a/Plugin/Locale/Format.php
+++ b/Plugin/Locale/Format.php
@@ -21,18 +21,9 @@
 
 namespace Mageplaza\CurrencyFormatter\Plugin\Locale;
 
-use Magento\Checkout\Model\Session;
-use Magento\Directory\Model\Currency\DefaultLocator;
-use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Framework\Locale\CurrencyInterface;
 use Magento\Framework\Locale\Format as LocaleFormat;
-use Magento\Framework\Locale\FormatInterface;
-use Magento\Framework\Locale\ResolverInterface;
-use Magento\Store\Model\StoreManagerInterface;
-use Mageplaza\CurrencyFormatter\Helper\Data as HelperData;
-use Mageplaza\CurrencyFormatter\Model\Locale\DefaultFormat;
 use Mageplaza\CurrencyFormatter\Plugin\AbstractFormat;
 
 /**
@@ -41,48 +32,6 @@ use Mageplaza\CurrencyFormatter\Plugin\AbstractFormat;
  */
 class Format extends AbstractFormat
 {
-    /**
-     * @var Session
-     */
-    protected $_checkoutSession;
-
-    /**
-     * AbstractFormat constructor.
-     *
-     * @param StoreManagerInterface $storeManager
-     * @param HelperData $helperData
-     * @param ResolverInterface $localeResolver
-     * @param CurrencyInterface $localeCurrency
-     * @param FormatInterface $localeFormat
-     * @param DefaultFormat $defaultFormat
-     * @param DefaultLocator $currencyLocator
-     * @param RequestInterface $request
-     * @param Session $checkoutSession
-     */
-    public function __construct(
-        StoreManagerInterface $storeManager,
-        HelperData $helperData,
-        ResolverInterface $localeResolver,
-        CurrencyInterface $localeCurrency,
-        FormatInterface $localeFormat,
-        DefaultFormat $defaultFormat,
-        DefaultLocator $currencyLocator,
-        RequestInterface $request,
-        Session $checkoutSession
-    ) {
-        $this->_checkoutSession = $checkoutSession;
-        parent::__construct(
-            $storeManager,
-            $helperData,
-            $localeResolver,
-            $localeCurrency,
-            $localeFormat,
-            $defaultFormat,
-            $currencyLocator,
-            $request
-        );
-    }
-
     /**
      * @param LocaleFormat $subject
      * @param callable $proceed
@@ -120,14 +69,12 @@ class Format extends AbstractFormat
         if (!$this->_helperData->isEnabled()) {
             return $result;
         }
-        $baseCurrencyCode = $this->_checkoutSession->getQuote()->getBaseCurrencyCode();
-
+        $baseCurrencyCode = $this->_storeManager->getStore()->getBaseCurrency()->getCode();
         $code = $this->getCurrencyCode();
-        if ($baseCurrencyCode) {
-            if (isset($result['currencyCode']) && $result['currencyCode'] === $baseCurrencyCode) {
-                $code = $baseCurrencyCode;
-            }
+        if ($baseCurrencyCode && isset($result['currencyCode']) && $result['currencyCode'] === $baseCurrencyCode) {
+            $code = $baseCurrencyCode;
         }
+
         $config           = $this->getFormatByCurrency($code);
         $localeShowSymbol = $this->_helperData->getLocaleShowSymbol(
             $code,


### PR DESCRIPTION
### Description
I don't think it's necessary to load the entire quote since base currency is always the store base currency, see https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Quote/Model/Quote.php#L844

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
